### PR TITLE
Added CSS properties for the pre-loading page

### DIFF
--- a/style.css
+++ b/style.css
@@ -70,3 +70,81 @@ body {
   display: flex;
   /* justify-content: center; */
 }
+
+
+/*Preloading page CSS properties*/
+
+.pre-loader {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 100vh;
+  background-color: black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: opacity 1s ease-out;
+}
+
+#title-preload {
+  position: absolute;
+  font-family: 'pacfontregular';
+  font-size: 20px;
+  color:yellow;
+  top: 15%;
+  transform: translateY(-15%);
+  text-align: center;
+  animation: textzoom 10s;
+}
+
+.pacman {
+  position: absolute;
+  height: 40px;
+  width: 40px;
+  top: 60%;
+  left: 0%;
+  transform: translate(0%, -60%);
+  animation: pacman-run 10s none;
+}
+
+.ball {
+  position: absolute;
+  height: 20px;
+  width: 20px;
+  top: 60%;
+  left: 4%;
+  transform: translate(4%, -60%);
+  animation: ball-run 10s none;
+}
+
+.finish-load {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@keyframes textzoom {
+  0%{
+    font-size: 90px;
+  }
+  100%{
+    font-size: 125px;
+  }
+}
+
+@keyframes pacman-run {
+  from {
+    left: 0%;
+  }
+  to {
+    left: 100%;
+  }
+}
+
+@keyframes ball-run {
+  from {
+    left: 4%;
+  }
+  to {
+    left: 104%;
+  }
+}


### PR DESCRIPTION

/*Preloading page CSS properties*/

.pre-loader {
  position: fixed;
  top: 0;
  width: 100%;
  height: 100vh;
  background-color: black;
  display: flex;
  justify-content: center;
  align-items: center;
  transition: opacity 1s ease-out;
}

#title-preload {
  position: absolute;
  font-family: 'pacfontregular';
  font-size: 20px;
  color:yellow;
  top: 15%;
  transform: translateY(-15%);
  text-align: center;
  animation: textzoom 10s;
}

.pacman {
  position: absolute;
  height: 40px;
  width: 40px;
  top: 60%;
  left: 0%;
  transform: translate(0%, -60%);
  animation: pacman-run 10s none;
}

.ball {
  position: absolute;
  height: 20px;
  width: 20px;
  top: 60%;
  left: 4%;
  transform: translate(4%, -60%);
  animation: ball-run 10s none;
}

.finish-load {
  opacity: 0;
  pointer-events: none;
}

@keyframes textzoom {
  0%{
    font-size: 90px;
  }
  100%{
    font-size: 125px;
  }
}

@keyframes pacman-run {
  from {
    left: 0%;
  }
  to {
    left: 100%;
  }
}

@keyframes ball-run {
  from {
    left: 4%;
  }
  to {
    left: 104%;
  }
}

/* Properties end here */

We can play around with the timing later and change the images when we have them